### PR TITLE
use latest docker-compose version

### DIFF
--- a/nodepool/elements/wazo/post-install.d/60-docker
+++ b/nodepool/elements/wazo/post-install.d/60-docker
@@ -17,9 +17,13 @@ echo \
 
 apt-get update
 
-apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose
+apt-get install -y docker-ce docker-ce-cli containerd.io
 
 systemctl enable docker
+
+DOCKER_COMPOSE_VERSION='v2.2.3'
+curl -SL https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_VERSION/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
+chmod +x /usr/local/bin/docker-compose
 
 # No service running in chroot
 # systemctl start docker


### PR DESCRIPTION
why:
* Avoid python dependencies issue with older package
* Get latest available feature