### PR TITLE
Adding a new label to create VMs on openstack

### DIFF
--- a/nodepool/nodepool.yaml
+++ b/nodepool/nodepool.yaml
@@ -35,6 +35,8 @@ labels:
     min-ready: 0
   - name: vm-debian-10-m1m
     min-ready: 0
+  - name: pod-debian-11
+    min-ready: 2
 
 providers:
   - name: openstack2
@@ -55,6 +57,9 @@ providers:
           - wazo-production-sf-net
         labels:
           - name: vm-debian-11-m1s
+            flavor-name: wazo-sf-worker-small
+            diskimage: img-debian-11
+          - name: pod-debian-11
             flavor-name: wazo-sf-worker-small
             diskimage: img-debian-11
         availability-zones:


### PR DESCRIPTION
Adding a new label to create VMs on openstack instead of pods for debian 11. This is to allow the use of the pod-debian-11 in the pipelines while we fix the debian 11 container build fails on centos7/buildah 1.6.