### PR TITLE
Fixing docker-ce version for debian buster/bulleye

### DIFF
--- a/nodepool/elements/wazo/post-install.d/60-docker
+++ b/nodepool/elements/wazo/post-install.d/60-docker
@@ -17,7 +17,7 @@ echo \
 
 apt-get update
 
-apt-get install -y docker-ce docker-ce-cli containerd.io
+apt-get install -y docker-ce=5:20.* docker-ce-cli=5:20.* containerd.io
 
 systemctl enable docker
 


### PR DESCRIPTION
Why:
Since February 2nd/3rd, the latest docker-ce and docker-cli packages are now version 23.0. The new version have additional requirements that we will address in a separate task. 

In order to restore the behavior we had until the recent change, we will pin the docker-ce version to the latest 20.X version (20.10.23)