### PR TITLE
Install Docker's Apparmor dependencies

### DIFF
--- a/nodepool/elements/wazo/post-install.d/60-docker
+++ b/nodepool/elements/wazo/post-install.d/60-docker
@@ -11,8 +11,6 @@ apt-get install -y \
     apparmor \
     apparmor-utils
 
-
-
 curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
 
 echo \
@@ -22,6 +20,8 @@ echo \
 apt-get update
 
 apt-get install -y docker-ce=5:20.* docker-ce-cli=5:20.* containerd.io
+
+aa-complain /etc/apparmor.d/*
 
 systemctl enable docker
 

--- a/nodepool/elements/wazo/post-install.d/60-docker
+++ b/nodepool/elements/wazo/post-install.d/60-docker
@@ -7,7 +7,11 @@ apt-get install -y \
     ca-certificates \
     curl \
     gnupg \
-    lsb-release
+    lsb-release \
+    apparmor \
+    apparmor-utils
+
+
 
 curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
 

--- a/nodepool/elements/wazo/post-install.d/60-docker
+++ b/nodepool/elements/wazo/post-install.d/60-docker
@@ -19,7 +19,7 @@ echo \
 
 apt-get update
 
-apt-get install -y docker-ce=5:20.* docker-ce-cli=5:20.* containerd.io
+apt-get install -y docker-ce docker-ce-cli containerd.io
 
 aa-complain /etc/apparmor.d/*
 


### PR DESCRIPTION
Why:

The latest docker versions introduce a new issue for debian (same issue with docker 20.X):

https://docs.docker.com/engine/release-notes/23.0/

Known issues
Some Debian users have reported issues with containers failing to start after upgrading to the 23.0 version. The error message indicates that the issue is due to a missing apparmor_parser dependency:

`Error response from daemon: AppArmor enabled on system but the docker-default profile could not be loaded: running` `apparmor_parser apparmor_parser --version failed with output: `

`error: exec: "apparmor_parser": executable file not found in $PATH`
`Error: failed to start containers: somecontainer`

The workaround to this issue is to install the apparmor-utils package manually:

`apt-get install apparmor-utils`