### PR TITLE
remove apparmor complain mode

### DIFF
--- a/nodepool/elements/wazo/post-install.d/60-docker
+++ b/nodepool/elements/wazo/post-install.d/60-docker
@@ -21,8 +21,6 @@ apt-get update
 
 apt-get install -y docker-ce docker-ce-cli containerd.io
 
-aa-complain /etc/apparmor.d/*
-
 systemctl enable docker
 
 DOCKER_COMPOSE_VERSION='v2.2.3'


### PR DESCRIPTION
Why:
complain mode is generating ERRORs for some services:

Debian 10 & 11:
2023-02-07 14:26:29.245 | Warning: unable to find a suitable fs in /proc/mounts, is it mounted? 2023-02-07 14:26:29.245 | Use --subdomainfs to override.

Debian 11:

2023-02-07 14:26:29.245 | Setting /etc/apparmor.d/lsb_release to complain mode. 2023-02-07 14:26:29.245 |
2023-02-07 14:26:29.245 | ERROR: Cache read/write disabled: interface file missing. (Kernel needs AppArmor 2.4 compatibility patch.)