### PR TITLE
allow to write justification for regate comment

### DIFF
--- a/zuul.d/_pipelines.yaml
+++ b/zuul.d/_pipelines.yaml
@@ -63,7 +63,7 @@
           state: approved
         - event: pull_request
           action: comment
-          comment: (?i)^\s*regate\s*$
+          comment: (?i)^\s*regate
         - event: pull_request_review
           action: dismissed
           state: request_changes
@@ -167,7 +167,7 @@
       github.com:
         - event: pull_request
           action: comment
-          comment: (?i)^\s*check experimental\s*$
+          comment: (?i)^\s*check experimental
     success:
       github.com: {}
     failure:


### PR DESCRIPTION
why: use same behavior than "recheck".
We may want to write `regate (CI was down)`