### PR TITLE
include workaround-bindep role for any hosts

### DIFF
--- a/playbooks/base/pre.yaml
+++ b/playbooks/base/pre.yaml
@@ -16,8 +16,8 @@
         - include_role: name=validate-host
         - include_role: name=prepare-workspace
         - include_role: name=add-build-sshkey
-        - include_role: name=workaround-bindep
       when: "ansible_connection != 'kubectl'"
+    - include_role: name=workaround-bindep
     - block:
         - include_role: name=prepare-workspace-openshift
         - include_role: name=remove-zuul-sshkey


### PR DESCRIPTION
Why:
This is related to https://wazo-dev.atlassian.net/browse/IN-124.

The configuration was wiped by the last Automatic update of defaults.