### PR TITLE
add adm group to zuul-worker

### DIFF
--- a/nodepool/elements/wazo/post-install.d/60-log-permission
+++ b/nodepool/elements/wazo/post-install.d/60-log-permission
@@ -1,0 +1,3 @@
+#!/bin/sh -ex
+
+usermod --append --groups adm zuul-worker


### PR DESCRIPTION
why: allow zuul-worker to upload syslog