### PR TITLE
Remove zuul-test-job project from production

### DIFF
--- a/resources/resources.yaml
+++ b/resources/resources.yaml
@@ -15,12 +15,6 @@ resources:
       members:
         - dev+wazo-production-sf@wazo.io
   projects:
-    test:
-      description: "Testing Zuul itself"
-      connection: github.com
-      source-repositories:
-        - TinxHQ/zuul-test-job:
-            zuul/exclude-unprotected-branches: false
     wazo-platform:
       description: "Wazo Platform"
       connection: github.com


### PR DESCRIPTION
Why:
We need to use it in the development environement to be able to produce accurate tests.