### PR TITLE
Debian os family is a requirement for the role

### DIFF
--- a/playbooks/base/pre.yaml
+++ b/playbooks/base/pre.yaml
@@ -18,6 +18,7 @@
         - include_role: name=add-build-sshkey
       when: "ansible_connection != 'kubectl'"
     - include_role: name=workaround-bindep
+      when: "ansible_os_family == 'Debian'"
     - block:
         - include_role: name=prepare-workspace-openshift
         - include_role: name=remove-zuul-sshkey


### PR DESCRIPTION
Why:
Some default jobs such as `linters` uses centos-7 pods and the workaround-bindep role does not support any other OS family than Debian (this includes Ubuntu)