### PR TITLE
nodepool elements: sets a static resolvconf file for the nodepool nodes

### DIFF
--- a/nodepool/elements/wazo/post-install.d/55-resolvconf
+++ b/nodepool/elements/wazo/post-install.d/55-resolvconf
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+cat <<EOF >/etc/resolv.conf
+search node.production.wazo service.production.wazo zuul.wazo.community
+nameserver 8.8.8.8
+EOF


### PR DESCRIPTION
**why**
We have an issue regarding nodepool nodes, their configuration is copied from SF manager. It makes some tests fail because nameservers are bad and resolution fails