### PR TITLE
Fix resolv.conf file to customize

### DIFF
--- a/nodepool/elements/wazo/post-install.d/55-resolvconf
+++ b/nodepool/elements/wazo/post-install.d/55-resolvconf
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-cat <<EOF >/etc/resolv.conf
+cat <<EOF >/etc/resolv.conf.ORIG
 search node.production.wazo service.production.wazo zuul.wazo.community
 nameserver 8.8.8.8
 EOF


### PR DESCRIPTION
image-builder is in fact overriding /etc/resolv.conf at the end of the building process making our step to customize it not functional.
As per [git@github.com:TinxHQ/wazo-production-sf-config.git](https://docs.openstack.org/diskimage-builder/latest/user_guide/building_an_image.html#nameservers) we can use /etc/resolv.conf.ORIG to customize it.