### PR TITLE
encapsulate-tox-in-venv

### DIFF
--- a/nodepool/elements/wazo/post-install.d/50-requirements
+++ b/nodepool/elements/wazo/post-install.d/50-requirements
@@ -21,6 +21,10 @@ apt-get install -y \
     tar \
     unzip
 
-pip3 install tox
+# Create global virtualenv to avoid conflict with apt packages
+python3 -m venv /opt/global-venv
+source /opt/global-venv/bin/activate
+pip install tox
+ln -s /opt/global-venv/bin/tox /usr/local/bin/tox
 
 systemctl enable cron


### PR DESCRIPTION
why: to avoid conflict with apt packaging system (required by bookworm
distro)
