### PR TITLE
resources: add TinxHQ/zuul-test-job

### DIFF
--- a/resources/resources.yaml
+++ b/resources/resources.yaml
@@ -19,6 +19,8 @@ resources:
       description: "Wazo Platform"
       connection: github.com
       source-repositories:
+        - TinxHQ/zuul-test-job:
+            zuul/exclude-unprotected-branches: true
         - wazo-platform/.github:
             zuul/exclude-unprotected-branches: true
         - wazo-platform/ansible-role-consul-service:


### PR DESCRIPTION
**why**
We need a project for testing our pipeline, some assessment that if a pipeline does not work anymore, it is because of the pipeline and not the whole install


**Warning**: config already already in place. I had to manually add it and restart zuul to make that happen. For a reason sfconfig did not repopulate this part...